### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.7
+
+# Install the dependencies.
+RUN apk add --no-cache \
+    php7 \
+    php7-curl \
+    php7-dom \
+    php7-tokenizer \
+    php7-xdebug
+
+# Enable xdebug for code coverage.
+RUN echo zend_extension=xdebug.so >> /etc/php7/conf.d/xdebug.ini
+
+# Create and set the working directory to /package.
+RUN mkdir /package
+WORKDIR /package

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  package:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/package
+    tty: true


### PR DESCRIPTION
This branch adds docker support to the package for testing purposes.

To install the package dependencies:

```
docker run --rm -v $(pwd):/app composer:latest install --no-interaction --no-suggest
```

To run the test suite from the docker container:

```
docker-compose up -d
docker-compose exec package vendor/bin/phpunit --coverage-text
```