### PR TITLE
Fix incorrect variable reference

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -387,7 +387,7 @@ class Client implements ClientInterface
         string $remoteFile,
         string $localFile
     ) : ClientInterface {
-        $received = ssh2_scp_recv($this->connection, $localFile, $remoteFile);
+        $received = ssh2_scp_recv($this->connection, $remoteFile, $localFile);
 
         if (! $received) {
             throw new CommandException(


### PR DESCRIPTION
Fixed reference to variables. The arguments `$localFile` and `$remoteFile` were swapped.